### PR TITLE
feat: Add legal and privacy pages, introduce footer component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { FrameProvider } from "@/context/FrameProvider";
 import { WagmiContext } from "@/context/wagmiContext";
 import { MiniAppContext } from "@/context/miniAppContext";
 import { Toaster } from "@/components/ui/sonner";
+import { Footer } from "@/components/bottom/footer";
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
@@ -55,6 +56,7 @@ export default function RootLayout({
             <FrameProvider>
               {children}
               <Toaster expand={true} richColors />
+              <Footer />
             </FrameProvider>
           </MiniAppContext>
         </WagmiContext>

--- a/app/legal/page.tsx
+++ b/app/legal/page.tsx
@@ -1,0 +1,53 @@
+export default function Legal() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12">
+      <h1 className="text-3xl font-bold mb-6">{"Terms & Conditions"}</h1>
+
+      <p className="mb-2 text-sm text-gray-500">Effective Date: June 23, 2025</p>
+      <p className="mb-6">Operated by: 3WB Labs Inc. (Delaware Corporation)</p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">1. Acceptance of Terms</h2>
+      <p className="mb-4">By accessing or using the 3WB Fleet Financing Platform ("Platform"), you agree to be legally bound by these Terms. If you do not agree, do not use the Platform.</p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">2. Eligibility</h2>
+      <ul className="list-disc pl-6 mb-4">
+        <li>Be at least 18 years old</li>
+        <li>Be legally permitted to participate in investment opportunities under your local laws</li>
+        <li>Provide accurate KYC information (email, ID, etc.)</li>
+      </ul>
+      <p className="mb-4">We reserve the right to refuse access to anyone for any reason.</p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">3. Nature of the Platform</h2>
+      <p className="mb-4">The Platform enables you to fund three-wheeler vehicles through fractional or full contributions. Your funds are pooled to finance vehicles leased to vetted drivers in our operating markets. This is not a lending or deposit-taking platform. Your participation is at your own risk.</p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">4. Returns & Payouts</h2>
+      <p className="mb-4">Returns are generated from weekly payments made by drivers under hire-purchase agreements. You may receive weekly payouts proportionate to your funded amount over the lease term (typically ~60 weeks). Return estimates (e.g. 75% ROI) are not guaranteed and are subject to driver performance and platform risk.</p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">5. Ownership and Asset Structure</h2>
+      <p className="mb-4">All vehicles remain the property of 3WB Labs Inc. or its designated fleet partners until fully paid off. Investors do not take legal title to the vehicles but have a contractual right to income from assigned assets. Vehicles may be reassigned if a driver defaults or exits early.</p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">6. Risk Disclosure</h2>
+      <ul className="list-disc pl-6 mb-4">
+        <li>Your capital is at risk.</li>
+        <li>Returns depend on real-world performance.</li>
+        <li>While 3WB Labs Inc. uses vetting, pooling, and reserves to mitigate risk, losses are possible.</li>
+      </ul>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">7. Changes to Terms</h2>
+      <p className="mb-4">We may modify these Terms at any time. Updates will be posted on the Platform. Continued use means acceptance of the changes.</p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">8. Termination</h2>
+      <ul className="list-disc pl-6 mb-4">
+        <li>Provide false information</li>
+        <li>Attempt to misuse the platform</li>
+        <li>Violate applicable laws or these Terms</li>
+      </ul>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">9. Governing Law</h2>
+      <p className="mb-4">These Terms are governed by the laws of the State of Delaware, USA. Any disputes shall be resolved exclusively in Delaware courts.</p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">10. Contact</h2>
+      <p className="mb-4">For questions, reach us at: <a href="mailto:3wheelerbikeclub@gmail.com" className="text-blue-600 underline">3wheelerbikeclub@gmail.com</a></p>
+    </div>
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,49 @@
+export default function Privacy() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12">
+      <h1 className="text-3xl font-bold mb-6">Privacy Policy</h1>
+
+      <p className="mb-2 text-sm text-gray-500">Effective Date: June 23, 2025</p>
+      <p className="mb-6">Company: 3WB Labs Inc.<br/>Platform: 3WB Fleet Financing Platform</p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">1. Information We Collect</h2>
+      <p>We collect the following personal information:</p>
+      <ul className="list-disc pl-6 mb-4">
+        <li>Full name</li>
+        <li>Email address</li>
+        <li>Phone number</li>
+        <li>Government-issued ID (e.g., passport or national ID)</li>
+        <li>Wallet address or payment reference (if applicable)</li>
+      </ul>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">2. Why We Collect It</h2>
+      <p>We use this data to:</p>
+      <ul className="list-disc pl-6 mb-4">
+        <li>Verify identity (KYC)</li>
+        <li>Process fleet financing applications</li>
+        <li>Ensure compliance with legal requirements</li>
+        <li>Communicate with users</li>
+      </ul>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">3. How We Protect It</h2>
+      <p className="mb-4">Your data is stored securely and only accessed by authorized personnel. We implement encryption and other security measures to prevent unauthorized access.</p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">4. Sharing of Data</h2>
+      <p>We may share your information with:</p>
+      <ul className="list-disc pl-6 mb-4">
+        <li>Identity verification partners</li>
+        <li>Payment processors</li>
+        <li>Legal or regulatory authorities if required</li>
+      </ul>
+      <p className="mb-4">We do not sell or rent your personal data.</p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">5. Your Rights</h2>
+      <p>You have the right to:</p>
+      <ul className="list-disc pl-6 mb-4">
+        <li>Access or update your personal data</li>
+        <li>Request deletion of your data (unless required to retain it by law)</li>
+      </ul>
+      <p className="mb-4">To exercise your rights, contact: <a href="mailto:3wheelerbikeclub@gmail.com" className="text-blue-600 underline">3wheelerbikeclub@gmail.com</a></p>
+    </div>
+  );
+}

--- a/components/bottom/footer.tsx
+++ b/components/bottom/footer.tsx
@@ -1,0 +1,19 @@
+import Image from "next/image";
+
+
+export function Footer() {
+    return (
+        <div className="flex flex-col w-full gap-5 items-center justify-center px-4 mb-4">
+            
+            <div className="flex flex-row gap-5 text-xs max-md:text-[8px]">  
+                <a href="https://warp.3wb.club/privacy" target="_blank" rel="noopener noreferrer">
+                    <p className="text-yellow-600 underline">{"Privacy Policy"}</p>
+                </a>
+                <a href="https://warp.3wb.club/legal" target="_blank" rel="noopener noreferrer">
+                    <p className="text-yellow-600 underline">{"Terms of Service"}</p>
+                </a>
+            </div>
+            <p className="text-xs max-md:text-[8px]">{"© 2025 3WB LABS INC. <> 3WB GHANA LTD. All rights reserved."}</p>
+        </div>
+    );
+}

--- a/components/landing/wrapper.tsx
+++ b/components/landing/wrapper.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 
 import { Button } from "../ui/button";
-import { Wallet, TrendingUp, ShieldCheck } from "lucide-react";
+import { Wallet, TrendingUp, ShieldCheck, ChartNoAxesCombined } from "lucide-react";
 import Image from "next/image";
 import { useAccount } from "wagmi";
 
@@ -44,7 +44,7 @@ export function Wrapper() {
                     <div className="flex flex-col items-center p-8 rounded-2xl border">
                         <TrendingUp className="w-16 h-16 mb-6" />
                         <h3 className="text-lg text-center font-semibold mb-4">High Returns</h3>
-                        <p className="text-center text-sm">Earn up to 2x returns on fleet investments</p>
+                        <p className="text-center text-sm">Targets up to 45% returns on fleet investments</p>
                     </div>
                     
                     <div className="flex flex-col items-center p-8 rounded-2xl border">
@@ -56,22 +56,21 @@ export function Wrapper() {
                     <div className="flex flex-col items-center p-8 rounded-2xl border">
                         <Wallet className="w-16 h-16 mb-6" />
                         <h3 className="text-lg text-center font-semibold mb-4">Passive Income</h3>
-                        <p className="text-center text-sm">Regular returns from fleet operations</p>
+                        <p className="text-center text-sm">On-time weekly returns from fleet operations</p>
                     </div>
                 </div>
 
                 <Button 
                     onClick={Login} 
                     disabled={!isConnected}
-                    className="w-64 h-16 text-base font-semibold rounded-3xl"
+                    className="rounded-full px-12 py-7 max-sm:px-8 max-sm:py-6"
                 >
-                    <p>START EARNING</p>
+                    <div className="flex">
+                        <ChartNoAxesCombined />
+                    </div>
+                    Start Earning
                 </Button>
             </div>
-
-            <footer className="w-full text-center py-4 text-sm">
-                {"© 2025 3WB LABS INC. <> 3WB GHANA LTD. All rights reserved."}
-            </footer>
         </div>
     );
 }

--- a/hooks/useDivvi.tsx
+++ b/hooks/useDivvi.tsx
@@ -3,7 +3,7 @@ import { fleetOrderBook } from "@/utils/constants/addresses"
 import { getDataSuffix, submitReferral } from "@divvi/referral-sdk"
 import { useState } from "react"
 import { toast } from "sonner"
-import { createWalletClient, encodeFunctionData, erc20Abi, http, maxUint256 } from "viem"
+import { encodeFunctionData, erc20Abi, maxUint256 } from "viem"
 import { celo } from "viem/chains"
 import { useAccount, useSendTransaction, useSwitchChain } from "wagmi"
 


### PR DESCRIPTION
Added new Terms & Conditions and Privacy Policy pages under /legal and /privacy. Introduced a reusable Footer component and integrated it into the main layout, replacing the previous static footer in the landing wrapper. Updated landing page copy for returns and passive income, and improved the call-to-action button. Minor cleanup in useDivvi hook by removing unused imports.