### PR TITLE
feat: Connect only when MiniApp is ready

### DIFF
--- a/context/connectContext.tsx
+++ b/context/connectContext.tsx
@@ -3,14 +3,23 @@
 import { useEffect } from "react";
 import { useConnect } from "wagmi";
 import { farcasterMiniApp as miniAppConnector } from "@farcaster/miniapp-wagmi-connector";
+import { sdk } from "@farcaster/miniapp-sdk"
 
 
 export const ConnectContext = ({ children }: { children: React.ReactNode }) => {
 
     const { connect } = useConnect();
-      
-    useEffect(() => {
-        connect({ connector: miniAppConnector() });
+
+    const checkMiniAppPlusReady = async () => {
+        const isMiniApp = await sdk.isInMiniApp()
+        const isReady = await sdk.actions.ready()
+        if (isMiniApp && isReady) {
+            connect({ connector: miniAppConnector() });
+        }
+    }
+    
+    useEffect( () => {
+        checkMiniAppPlusReady()
     }, []);
 
     return (


### PR DESCRIPTION
Adds a check to ensure the app is running inside a MiniApp and is ready before attempting to connect using the miniAppConnector. This prevents premature connection attempts and improves reliability.