### PR TITLE
fix: Use min-h-screen for Fleet page container

### DIFF
--- a/app/fleet/page.tsx
+++ b/app/fleet/page.tsx
@@ -3,7 +3,7 @@ import { Wrapper } from "@/components/fleet/wrapper";
 export default function Fleet() {
 
   return (
-    <div className="flex flex-col w-full h-screen">
+    <div className="flex flex-col w-full min-h-screen">
       <Wrapper/>
     </div>
   );


### PR DESCRIPTION
Replaces h-screen with min-h-screen on the Fleet page container to ensure the content stretches to at least the viewport height but can grow if needed.