### PR TITLE
feat: Remove unused writeContractAsync import

### DIFF
--- a/components/fleet/buy/wrapper.tsx
+++ b/components/fleet/buy/wrapper.tsx
@@ -49,8 +49,6 @@ export function Wrapper() {
 
     const router = useRouter()
     
-    
-    const { writeContractAsync } = useWriteContract()
 
     const fleetFractionPriceQueryClient = useQueryClient()
     const allowanceCeloDollarQueryClient = useQueryClient()


### PR DESCRIPTION
Deleted the unused writeContractAsync import from the Wrapper component to clean up the code.