### PR TITLE
feat: Update referral SDK usage in useDivvi hook

### DIFF
--- a/hooks/useDivvi.tsx
+++ b/hooks/useDivvi.tsx
@@ -1,17 +1,17 @@
 import { publicClient } from "@/utils/client"
 import { fleetOrderBook } from "@/utils/constants/addresses"
-import { getDataSuffix, submitReferral } from "@divvi/referral-sdk"
+import { getReferralTag, submitReferral } from "@divvi/referral-sdk"
 import { useState } from "react"
 import { toast } from "sonner"
 import { encodeFunctionData, erc20Abi, maxUint256 } from "viem"
 import { celo } from "viem/chains"
-import { useAccount, useSendTransaction, useSwitchChain } from "wagmi"
+import { useAccount, useSendTransaction, useSwitchChain } from "wagmi";
 
 
 export const useDivvi = () => {
   
     const [loading, setLoading] = useState(false)
-    const { sendTransactionAsync } = useSendTransaction()
+    const { sendTransactionAsync } = useSendTransaction();
     const { chainId } = useAccount()
     const { switchChainAsync } = useSwitchChain()
 
@@ -26,35 +26,35 @@ export const useDivvi = () => {
           args: [fleetOrderBook, maxUint256]
         })
         
-        // Step 1: Execute an existing transaction within your codebase with the referral data suffix
 
         // consumer is your Divvi Identifier
-        // providers are the addresses of the Rewards Campaigns that you signed up for on the previous page
-        const dataSuffix = getDataSuffix({
+        // generate a referral tag for the user
+        const referralTag  = getReferralTag({
+          user: account,
           consumer: "0x99342D3CE2d10C34b7d20D960EA75bd742aec468",
-          providers: ["0x5f0a55FaD9424ac99429f635dfb9bF20c3360Ab8", "0xB06a1b291863f923E7417E9F302e2a84018c33C5", "0x6226ddE08402642964f9A6de844ea3116F0dFc7e", "0x0423189886D7966f0DD7E7d256898DAeEE625dca"],
         })
 
         if (chainId !== celo.id) {
           await switchChainAsync({ chainId: celo.id })
         }
         
-        const tx = await sendTransactionAsync({
+        //Send the transaction your dapp was already going to perform (e.g. swap, transfer, contract interaction), but add the referral tag to the `data` field to enable attribution tracking.
+        const hash = await sendTransactionAsync({
           to: to,
-          data: data + dataSuffix as `0x${string}`,
+          data: data + referralTag as `0x${string}`,
           value: BigInt(0),
           chainId: celo.id
         })
         
         const transaction = await publicClient.waitForTransactionReceipt({
           confirmations: 1,
-          hash: tx
+          hash: hash
         })
 
-        // Step 2: Report the transaction to the attribution tracking API
+        // Report the transaction to Divvi by calling `submitReferral`. Divvi will later decode the referral metadata from the transaction data and record the referral on-chain via the DivviRegistry contract.
         if (transaction) {
           await submitReferral({
-            txHash: tx,
+            txHash: hash,
             chainId: celo.id
           })
         }


### PR DESCRIPTION
Replaces getDataSuffix with getReferralTag from @divvi/referral-sdk and updates transaction data construction to use referralTag. Improves comments for clarity on referral tag generation and reporting to Divvi.