### PR TITLE
feat: Update contract calls for fleet order functions

### DIFF
--- a/components/fleet/buy/wrapper.tsx
+++ b/components/fleet/buy/wrapper.tsx
@@ -156,7 +156,7 @@ export function Wrapper() {
                 data: encodeFunctionData({
                     abi: fleetOrderBookAbi,
                     functionName: "orderFleet",
-                    args: [BigInt(amount), cUSD],
+                    args: [BigInt(amount), cUSD, address!],
                 }),
                 chainId: celo.id,
             })
@@ -195,7 +195,7 @@ export function Wrapper() {
                 data: encodeFunctionData({
                     abi: fleetOrderBookAbi,
                     functionName: "orderFleetFraction",
-                    args: [BigInt(shares), cUSD],
+                    args: [BigInt(shares), cUSD, address!],
                 }),
                 chainId: celo.id,
             })

--- a/components/fleet/id.tsx
+++ b/components/fleet/id.tsx
@@ -28,7 +28,7 @@ export function Id( {fleet}: IdProps ) {
     const { data: isfleetFractioned, queryKey: isfleetFractionedQueryKey } = useReadContract({
         address: fleetOrderBook,
         abi: fleetOrderBookAbi,
-        functionName: "fleetFractioned",
+        functionName: "getFleetFractioned",
         args: [BigInt(Number(fleet))],
     })
     useEffect(() => { 
@@ -50,7 +50,7 @@ export function Id( {fleet}: IdProps ) {
     const { data: totalFractions, queryKey: totalFractionsQueryKey } = useReadContract({
         address: fleetOrderBook,
         abi: fleetOrderBookAbi,
-        functionName: "totalFractions",
+        functionName: "totalSupply",
         args: [BigInt(Number(fleet))],
     })
     useEffect(() => { 


### PR DESCRIPTION
Added address argument to 'orderFleet' and 'orderFleetFraction' contract calls in wrapper.tsx. Renamed contract function calls in id.tsx to 'getFleetFractioned' and 'totalSupply' for improved accuracy and compatibility with updated ABI.