### PR TITLE
feat: Refactor fleet buy wrapper to remove unused celoUSD logic

### DIFF
--- a/components/fleet/buy/wrapper.tsx
+++ b/components/fleet/buy/wrapper.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useRouter } from "next/navigation";
-import { useAccount, useBlockNumber, useReadContract, useSendTransaction, useSwitchChain, useWriteContract } from "wagmi";
+import { useAccount, useBlockNumber, useReadContract } from "wagmi";
 import { Button } from "@/components/ui/button"
 import {
   Drawer,
@@ -19,7 +19,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { divvi, cUSD, fleetOrderBook } from "@/utils/constants/addresses";
 import { fleetOrderBookAbi } from "@/utils/abis/fleetOrderBook";
-import { encodeFunctionData, erc20Abi, formatUnits } from "viem";
+import { erc20Abi, formatUnits } from "viem";
 import { celo, optimism } from "viem/chains";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
@@ -27,7 +27,6 @@ import { divviAbi } from "@/utils/abis/divvi";
 import { useApprove } from "@/hooks/useApprove";
 import { useOrderFleet } from "@/hooks/useOrderFleet";
 import { useOrderFleetFraction } from "@/hooks/useOrderFleetFraction";
-import { publicClient } from "@/utils/client";
 import { OnRamp } from "@/components/fleet/buy/onRamp";
 
 
@@ -35,14 +34,12 @@ import { OnRamp } from "@/components/fleet/buy/onRamp";
 
 export function Wrapper() {
 
-    const { address, chainId } = useAccount()
-    const { switchChainAsync } = useSwitchChain()
+    const { address } = useAccount()
 
     const [openDrawer, setOpenDrawer] = useState(true)
 
     const [amount, setAmount] = useState(1)
     const [fractions, setFractions] = useState(1)
-    const [loadingCeloUSD, setLoadingCeloUSD] = useState(false)
     const [loadingAddCeloDollar, setLoadingAddCeloDollar] = useState(false)
     const [isFractionsMode, setIsFractionsMode] = useState(true)
 
@@ -59,7 +56,7 @@ export function Wrapper() {
     const compliantQueryClient = useQueryClient()
     const { data: blockNumber } = useBlockNumber({ watch: true }) 
 
-    const { sendTransactionAsync } = useSendTransaction()
+    
     const { approve, loadingApproval } = useApprove()
     const { orderFleet, loadingOrderFleet } = useOrderFleet()
     const { orderFleetFraction, loadingOrderFleetFraction } = useOrderFleetFraction()
@@ -145,88 +142,6 @@ export function Wrapper() {
     }, [blockNumber, compliantQueryClient, compliantQueryKey]) 
 
    
-
-/*
-    // order multiple fleet with celoUSD
-    async function orderFleetWithCeloUSD() { 
-        try {
-            setLoadingCeloUSD(true)
-            if (chainId !== celo.id) {
-               await switchChainAsync({ chainId: celo.id })
-            }
-            const hash = await sendTransactionAsync({
-                to: fleetOrderBook,
-                data: encodeFunctionData({
-                    abi: fleetOrderBookAbi,
-                    functionName: "orderFleet",
-                    args: [BigInt(amount), cUSD, address!],
-                }),
-                chainId: celo.id,
-            })
-            const transaction = await publicClient.waitForTransactionReceipt({
-                confirmations: 1,
-                hash: hash
-            })
-              
-            if (transaction) {
-                //success toast
-                toast.success("Purchase successful", {
-                    description: `You can now view your ${amount > 1 ? "3-Wheelers" : " 3-Wheeler"} in your fleet`,
-                })
-                setLoadingCeloUSD(false)
-                router.push("/fleet")
-            }
-        } catch (error) {
-            console.log(error)
-            toast.error("Purchase failed", {
-                description: `Something went wrong, please try again`,
-            })
-            setLoadingCeloUSD(false)
-        }
-    }
-*/
-
-/*
-    // order fleet fractions & single 3-Wheeler with celoUSD
-    async function orderFleetFractionsWithCeloUSD( shares: number ) {    
-        try {
-            setLoadingCeloUSD(true)
-            if (chainId !== celo.id) {
-                await switchChainAsync({ chainId: celo.id })
-            }
-            const hash = await sendTransactionAsync({
-                to: fleetOrderBook,
-                data: encodeFunctionData({
-                    abi: fleetOrderBookAbi,
-                    functionName: "orderFleetFraction",
-                    args: [BigInt(shares), cUSD, address!],
-                }),
-                chainId: celo.id,
-            })
-            const transaction = await publicClient.waitForTransactionReceipt({
-                confirmations: 1,
-                hash: hash
-            })
-
-            if (transaction) {
-                //success toast
-                toast.success("Purchase successful", {
-                    description: `You can now view your 3-Wheeler ${shares == 50 ? "" : `${shares > 1 ? "fractions" : "fraction"}`} in your fleet`,
-                })
-
-                setLoadingCeloUSD(false)
-                router.push("/fleet")
-            }
-        } catch (error) {
-            console.log(error)
-            toast.error("Purchase failed", {
-                description: `Something went wrong, please try again`,
-            })
-            setLoadingCeloUSD(false)
-        }
-    }
-*/
-
     const onRamp = () => {
         setLoadingAddCeloDollar(true)
         setOpenOnRamp(true)
@@ -292,7 +207,7 @@ export function Wrapper() {
                                         size="icon"
                                         className="h-8 w-8 shrink-0 rounded-full"
                                         onClick={isFractionsMode ? decreaseFractions : decrease}
-                                        disabled={ isFractionsMode ? fractions <= 1 : amount <= 1 || loadingApproval || loadingCeloUSD || ( allowanceCeloUSD == BigInt(0)) }
+                                        disabled={ isFractionsMode ? fractions <= 1 : amount <= 1 || loadingApproval || loadingOrderFleet || loadingOrderFleetFraction || ( allowanceCeloUSD == BigInt(0)) }
 
                                     >
                                         <Minus />
@@ -314,7 +229,7 @@ export function Wrapper() {
                                         size="icon"
                                         className="h-8 w-8 shrink-0 rounded-full"
                                         onClick={isFractionsMode ? increaseFractions : increase}
-                                        disabled={ (isFractionsMode ? fractions >= 50 : amount >= 3) || loadingApproval || loadingCeloUSD || ( allowanceCeloUSD == BigInt(0)) }
+                                        disabled={ (isFractionsMode ? fractions >= 50 : amount >= 3) || loadingApproval || loadingOrderFleet || loadingOrderFleetFraction || ( allowanceCeloUSD == BigInt(0)) }
                                     >
                                         <Plus />
                                         <span className="sr-only">Increase</span>
@@ -330,7 +245,7 @@ export function Wrapper() {
                                     {/**pay with celoUSD */}
                                     <Button 
                                         className={` ${allowanceCeloUSD && allowanceCeloUSD > 0 ? "w-full hover:bg-yellow-600" : "w-full bg-yellow-300 hover:bg-yellow-400"}` }
-                                        disabled={loadingCeloUSD  || loadingApproval} 
+                                        disabled={loadingOrderFleet || loadingOrderFleetFraction  || loadingApproval} 
                                         onClick={() => {
                                             if (allowanceCeloUSD && allowanceCeloUSD > 0) {
                                                 if (isFractionsMode) {
@@ -364,7 +279,7 @@ export function Wrapper() {
                                         }}
                                     >
                                         {
-                                            loadingCeloUSD || loadingApproval || loadingAddCeloDollar
+                                            loadingOrderFleet || loadingOrderFleetFraction || loadingApproval || loadingAddCeloDollar
                                             ? (
                                                 <Loader2 className="w-4 h-4 animate-spin" /> 
                                             )


### PR DESCRIPTION
Removed unused celoUSD transaction logic and related state from the fleet buy wrapper. Updated button and control loading states to use orderFleet and orderFleetFraction loading flags instead of the previous loadingCeloUSD state.