### PR TITLE
feat: Reorder context providers in RootLayout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -52,13 +52,13 @@ export default function RootLayout({
         className={`${geistMono.className}`}
       >
         <WagmiContext>
-          <ConnectContext>
-            <MiniAppProvider>
+          <MiniAppProvider>
+            <ConnectContext>
               {children}
-              <Toaster expand={true} richColors />
-              <Footer />
-            </MiniAppProvider>
-          </ConnectContext>
+            </ConnectContext>
+            <Toaster expand={true} richColors />
+            <Footer />
+          </MiniAppProvider>
         </WagmiContext>
       </body>
     </html>


### PR DESCRIPTION
Swapped the order of MiniAppProvider and ConnectContext in the component tree to ensure correct context propagation and component behavior.